### PR TITLE
Fix drawing a lower zoom level

### DIFF
--- a/DrawHelper.js
+++ b/DrawHelper.js
@@ -935,10 +935,7 @@ var DrawHelper = (function() {
                         if(typeof options.callback == 'function') {
                             // remove overlapping ones
                             var index = positions.length - 1;
-                            // TODO - calculate some epsilon based on the zoom level
-                            var epsilon = Cesium.Math.EPSILON3;
-                            for(; index > 0 && positions[index].equalsEpsilon(positions[index - 1], epsilon); index--) {}
-                            options.callback(positions.splice(0, index + 1));
+                            options.callback(positions);
                         }
                     }
                 }


### PR DESCRIPTION
Don't remove points that are closer than a hard coded epsilon value.
The zoom level sets the miniumum distance one can set between
any two points.