### PR TITLE
Add fix  -  Issue #12 

### DIFF
--- a/DrawHelper.js
+++ b/DrawHelper.js
@@ -291,7 +291,7 @@ var DrawHelper = (function() {
                                 depthTest : {
                                     enabled : true
                                 },
-                                lineWidth : Math.min(this.strokeWidth || 4.0, context._aliasedLineWidthRange[1])
+                                lineWidth : this.strokeWidth || 4.0
                             }
                         })
                     });


### PR DESCRIPTION
Solving crash from issue #12  (line 294 not 249, probably a typo)

As far as I investigated, `context._aliasedLineWidthRange` is always `undefined`. 
Therefore, `Math.min()` operation is redundant and trying to read `context._aliasedLineWidthRange[1]` will make the system crash.